### PR TITLE
Positive hours should not round up. E.g. +9.5 becomes 10. Minutes sho…

### DIFF
--- a/templates/pages/index.twig
+++ b/templates/pages/index.twig
@@ -135,8 +135,8 @@
 
                             var when = new Date(response.data[0].when);
                             // The estimate doesn't have a time component, so copy the timezone from the generation date.
-                            var timezoneOffsetHours = Math.round(when.getTimezoneOffset() / -60).toString().replace(/^(-?)(\d)$/, '$10$2');
-                            var timezoneOffsetMins = (when.getTimezoneOffset() % 60).toString().replace(/^(\d)$/, '0$1');
+                            var timezoneOffsetHours = parseInt(when.getTimezoneOffset() / -60).toString().replace(/^(-?)(\d)$/, '$10$2');
+                            var timezoneOffsetMins = Math.abs(when.getTimezoneOffset() % 60).toString().replace(/^(\d)$/, '0$1');
                             var timezoneOffsetString = (when.getTimezoneOffset() > 0?'':'+') + timezoneOffsetHours + ":" + timezoneOffsetMins;
                             var estimateDateString = response.data[0].estimate.replace(/^(\d{4}-\d{2}-\d{2})$/, '$1T00:00:00' + timezoneOffsetString);
                             var estimateDate = new Date(estimateDateString);


### PR DESCRIPTION
…uld always be positive - hours handle the negative. E.g. -09:30.

For my timezone (Australia/Adelaide) on +9.5, estimateDateString is "2015-10-02T00:00:00+10:-30".
This change makes it "2015-10-02T00:00:00+09:30", which allows a valid date to be created.

I.e. new Date("2015-10-02T00:00:00+10:-30") results in:
```
Invalid Date
```