### PR TITLE
Add Drupal 8.0.0 release date

### DIFF
--- a/templates/pages/index.twig
+++ b/templates/pages/index.twig
@@ -3,6 +3,9 @@
 {% block content %}
     <div class="hero-unit">
         <h1>Drupal 8 Release</h1>
+        <section class="success">
+            <h2>November 19, 2015</h2>
+        </section>
         <section class="estimate">
             <h2 class="value">
                 ?


### PR DESCRIPTION
Per https://www.drupal.org/node/2605142, the official release date is November 19, 2015.